### PR TITLE
Multithreading, .bmp support, and threshold

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,14 +6,14 @@ from PIL import Image
 from flask import Flask, request, render_template
 
 app = Flask(__name__)
-ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif'])
+ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif', 'bmp'])
 CUTOFF = 2 ** 20
 
 def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1] in ALLOWED_EXTENSIONS
 
-def process_data_sequential(pixdata, xmin, xmax, ymin, ymax, threshold):
+def process_data_helper(pixdata, xmin, xmax, ymin, ymax, threshold):
     for x_pos in xrange(xmin, xmax):
         for y_pos in xrange(ymin, ymax):
             alpha = 255 - sum(pixdata[x_pos, y_pos][:3])/3
@@ -25,7 +25,7 @@ def process_data(pixdata, xmin, xmax, ymin, ymax, threshold):
     ysize = ymax-ymin
 
     if xsize*ysize < CUTOFF:
-        process_data_sequential(pixdata, xmin, xmax, ymin, ymax, threshold)
+        process_data_helper(pixdata, xmin, xmax, ymin, ymax, threshold)
         return
 
     if xsize > ysize:

--- a/main.py
+++ b/main.py
@@ -1,29 +1,67 @@
 from StringIO import StringIO
 import io
 import urllib
+from threading import Thread
 from PIL import Image
-from flask import Flask, redirect, request, url_for, render_template, send_file
+from flask import Flask, request, render_template
+
 app = Flask(__name__)
 ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif'])
+CUTOFF = 2 ** 20
 
 def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1] in ALLOWED_EXTENSIONS
 
-@app.route('/do', methods=[ 'POST'])
+def process_data_sequential(pixdata, xmin, xmax, ymin, ymax, threshold):
+    for x_pos in xrange(xmin, xmax):
+        for y_pos in xrange(ymin, ymax):
+            alpha = 255 - sum(pixdata[x_pos, y_pos][:3])/3
+            alpha = alpha if alpha > threshold else 0
+            pixdata[x_pos, y_pos] = tuple(pixdata[x_pos, y_pos][:3]) + (alpha,)
+
+def process_data(pixdata, xmin, xmax, ymin, ymax, threshold):
+    xsize = xmax-xmin
+    ysize = ymax-ymin
+
+    if xsize*ysize < CUTOFF:
+        process_data_sequential(pixdata, xmin, xmax, ymin, ymax, threshold)
+        return
+
+    if xsize > ysize:
+        processing_thread = Thread(target=process_data,
+                                   args=(pixdata,
+                                        0, xmax//2,
+                                        ymin, ymax,
+                                        threshold))
+        processing_thread.start()
+        process_data(pixdata, xmax//2, xmax, ymin, ymax, threshold)
+        processing_thread.join()
+
+    else:
+        processing_thread = Thread(target=process_data,
+                                            args=(pixdata,
+                                                  xmin, xmax,
+                                                  0, ymax//2,
+                                                  threshold))
+        processing_thread.start()
+        process_data(pixdata, xmin, xmax, ymax//2, ymax, threshold)
+        processing_thread.join()
+
+@app.route('/do', methods=['POST'])
 def upload_file():
     if request.method == 'POST':
         photo = request.files['file']
         if photo and allowed_file(photo.filename):
             in_memory_file = io.BytesIO()
             photo.save(in_memory_file)
-            img =Image.open(StringIO(in_memory_file.getvalue())).convert('RGBA')
+            img = Image.open(StringIO(in_memory_file.getvalue())).convert('RGBA')
 
-            pixdata= img.load()
-            for y in xrange(img.size[1]):
-                for x in xrange(img.size[0]):
-                    pixdata[x, y] = pixdata[x,y][:3] + \
-                                    (255-((pixdata[x, y][0] + pixdata[x, y][1] + pixdata[x, y][2])/3),)
+            pixdata = img.load()
+            xsize, ysize = img.size
+
+            process_data(pixdata, 0, xsize, 0, ysize, 0)
+
             outbuf = io.BytesIO()
             img.save(outbuf, format='PNG')
             b64 = outbuf.getvalue().encode('base64')


### PR DESCRIPTION
The threshold is still in progress (as I don't know how to do much web-based programming), but it essentially provides for the user an alpha level that it will simply turn transparent.

The big change includes a multi-threading feature. This uses divide-and-conquer to divide up the work for each thread. The helper is the original function, aside from a new ternary expression that accepts threshold. Currently, the cut-off is close to a million pixels (2 *\* 2). Also, added bmp in the top. It works automatically and is fully supported by pillow, so I included it.

Some unused imports were removed, and threading was imported.
